### PR TITLE
fix: Some issues that occur when starting StarryFramework

### DIFF
--- a/Assets/StarryFramework/Framework/Runtime/Base/FrameworkManager.cs
+++ b/Assets/StarryFramework/Framework/Runtime/Base/FrameworkManager.cs
@@ -53,10 +53,14 @@ namespace StarryFramework
 
         internal static void Awake()
         {
-
             foreach (ModuleType type in Setting.modules)
             {
-                managerTypeList.Add(GetManagerType(type));
+                var managerType = GetManagerType(type);
+                if (managerType == null)
+                {
+                    Debug.LogError($"{type} Module does not exist in the framework.");
+                }
+                else managerTypeList.Add(managerType);
             }
         }
 

--- a/Assets/StarryFramework/Framework/Runtime/Base/FrameworkSettings.cs
+++ b/Assets/StarryFramework/Framework/Runtime/Base/FrameworkSettings.cs
@@ -74,7 +74,7 @@ namespace StarryFramework
             {
                 if (check.Contains(type))
                 {
-                    Debug.LogError("Same components are not allowed in the Mpdule List");
+                    Debug.LogError("Same components are not allowed in the Module List");
                 }
                 else
                 {

--- a/Assets/StarryFramework/Framework/Runtime/Base/MainComponent.cs
+++ b/Assets/StarryFramework/Framework/Runtime/Base/MainComponent.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -130,29 +129,23 @@ namespace StarryFramework
         /// </summary>
         private void SetComponentsActive()
         {
-            Component[] components  = gameObject.GetComponentsInChildren<BaseComponent>();
+            BaseComponent[] components = gameObject.GetComponentsInChildren<BaseComponent>();
             foreach(BaseComponent component in components)
             {
                 try
                 {
-                    if(!component.Equals(this))
+                    ModuleType type = (ModuleType)Enum.Parse(typeof(ModuleType), component.gameObject.name);
+
+                    if (!frameworkSetting.modules.Contains(type))
                     {
-                        ModuleType type = (ModuleType)Enum.Parse(typeof(ModuleType), component.gameObject.name);
-
-                        if (!frameworkSetting.modules.Contains(type))
-                        {
-                            component.DisableProcess();
-                            component.gameObject.SetActive(false);
-                        }
+                        FrameworkManager.Debugger.Log($"Unused module: {type}");
+                        component.gameObject.SetActive(false);
                     }
-
                 }
                 catch
                 {
                     Debug.LogError("The Name of component gameObject can not be modified.");
-                    
                 }
-
             }
         }
     }

--- a/Assets/StarryFramework/Framework/Runtime/Save Module/SaveComponent.cs
+++ b/Assets/StarryFramework/Framework/Runtime/Save Module/SaveComponent.cs
@@ -1,7 +1,4 @@
-using Newtonsoft.Json;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Events;

--- a/Assets/StarryFramework/Framework/Runtime/Scene Module/Examples/ExampleLoadBar.cs
+++ b/Assets/StarryFramework/Framework/Runtime/Scene Module/Examples/ExampleLoadBar.cs
@@ -25,9 +25,22 @@ public class ExampleLoadBar : LoadProgressBase
     {
 
         _text.text = "Press any key to start.";
-        if(Input.anyKeyDown)
+        StartCoroutine(Routine());
+        return;
+
+        IEnumerator Routine()
         {
-            AllowSceneActivate(asyncOperation);
+            while(true)
+            {
+                if (Input.anyKeyDown)
+                {
+                    AllowSceneActivate(asyncOperation);
+                    break;
+                }
+
+                yield return null;
+            }
         }
+        
     }
 }

--- a/Assets/StarryFramework/Framework/Runtime/Scene Module/SceneChangeCameraControl.cs
+++ b/Assets/StarryFramework/Framework/Runtime/Scene Module/SceneChangeCameraControl.cs
@@ -5,15 +5,20 @@ using UnityEngine;
 
 namespace StarryFramework
 {
+    [RequireComponent(typeof(Camera))]
+    [RequireComponent(typeof(AudioListener))]
     public class SceneChangeCameraControl : MonoBehaviour
     {
         private Camera m_camera;
+        private AudioListener _audioListener;
         [SerializeField] private bool isMainCamera;
         private void Awake()
         {
             m_camera = GetComponent<Camera>();
+            _audioListener = GetComponent<AudioListener>();
             gameObject.tag = isMainCamera ? "MainCamera" : "Untagged";
             m_camera.enabled = isMainCamera;
+            _audioListener.enabled = isMainCamera;
             FrameworkManager.EventManager.AddEventListener(FrameworkEvent.StartSceneLoadAnim, SetCameraEnabled);
             FrameworkManager.EventManager.AddEventListener(FrameworkEvent.EndSceneLoadAnim, SetCameraNotEnabled);
         }
@@ -27,13 +32,19 @@ namespace StarryFramework
         private void SetCameraEnabled()
         {
             if(!isMainCamera)
+            {
                 m_camera.enabled = true;
+                _audioListener.enabled = true;
+            }
         }
         
         private void SetCameraNotEnabled()
         {
             if(!isMainCamera)
+            {
                 m_camera.enabled = false;
+                _audioListener.enabled = false;
+            }
         }
     }
 


### PR DESCRIPTION
尝试解决[Issue #3 ](https://github.com/starryforest-ymxk/StarryFramework/issues/3)中提出的问题。

两个commit分别解决了前两个和后两个问题：
1. 由于框架已经保证了MainComponent.Awake()将最先被调用，因此在其SetComponentsActive()方法中无需调用BaseComponent.DisableProcess()方法，因为对应的模块已经不为active，不会再进行注册；

2. 问题是由于这种情况下FrameworkManager中managerTypeList的内容和managers.Keys的内容并不完全相同，因为它们的来源不同。现添加了检查Settings中的Type是否都存在的逻辑。

3. 现将AudioListener的enable状态与Camera组件同步。

4. 问题是由于ExampleLoadBar.BeforeSetActive()中只调用了一次Input.anyKeyDown。现将该过程放入协程中。

希望这些改动能对项目有些帮助！